### PR TITLE
Update style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -135,8 +135,7 @@ img.logo-pic {
     }
     .box-3 {
         /*min-width: 20%;*/
-        margin-left: 25px;
-        margin: 0 20px 15px;
+        margin: 0 20px 25px;
     }
     .fw {
         margin-bottom: 25px;


### PR DESCRIPTION
In your MEDIA QUERIES section, you have a flexbox rule:

```
.box-3 {
    /*min-width: 20%;*/
    margin-left: 25px;
    margin: 0 20px 15px;
}
```

- The property `margin: 0 20px 15px`, overlaps the property `margin-left: 25px`.
- This is because you are declaring `margin-left` twice. 
- See how the rules works when declaring a property: `margin: 0 20px 15px` is interpreted as

```
margin-top: 0;
margin-right: 20px;
margin-bottom: 0; // This is because you did not declare any property. It defaults to  0.
margin-left: 15px; // You can see here why this overlaps the margin-left: 25px
```

- I would suggest that you remove the `margin-left: 25px`, and refactor the `margin` property like so:

```
margin: 0 20px 25px;
```